### PR TITLE
Fix 2FAS Invalid URL

### DIFF
--- a/CI trigger
+++ b/CI trigger
@@ -1,1 +1,0 @@
-Someone forgot to enable the CI before pushing :)

--- a/CI trigger
+++ b/CI trigger
@@ -1,0 +1,1 @@
+Someone forgot to enable the CI before pushing :)

--- a/interface/windows/import/index.ts
+++ b/interface/windows/import/index.ts
@@ -239,7 +239,7 @@ export const twoFasAuthFile = async () => {
 			console.log(service)
 
 			if (service.otp.tokenType === "TOTP") {
-				if (service.otp.source === "Link") {
+				if (service.otp.source === "Link" && service.otp.link !== undefined) {
 					importString += totpImageConverter(service.otp.link)
 				} else {
 					importString += totpImageConverter(`otpauth://totp/${service.name}?secret=${service.secret}&issuer=${service.name}`)

--- a/interface/windows/import/index.ts
+++ b/interface/windows/import/index.ts
@@ -239,7 +239,7 @@ export const twoFasAuthFile = async () => {
 			console.log(service)
 
 			if (service.otp.tokenType === "TOTP") {
-				if (service.otp.source === "Link" && service.otp.link !== undefined) {
+				if (service.otp.source === "Link" && service.otp.link !== undefined && service.otp.link.trim()) {
 					importString += totpImageConverter(service.otp.link)
 				} else {
 					importString += totpImageConverter(`otpauth://totp/${service.name}?secret=${service.secret}&issuer=${service.name}`)


### PR DESCRIPTION
# Reference issue

#318 

## Purpose

2FAS doesn't always come with the `services.otp.link` field, apparently.
This field seems to be used in the image getting/generation process.
This attempts to fix this.

## Approach

I am simply checking if the field is `undefined` or not.
Additionally, I am checking if the field actually has some text inside as, currently, you could have a `link: ""` field which most likely also would cause a crash.

## TODO

-   [X] Read [Contributing](https://github.com/Levminer/authme/blob/main/.github/CONTRIBUTING.md)
-   [X] Read [Code of conduct](https://github.com/Levminer/authme/blob/main/.github/CODE_OF_CONDUCT.md)
-   [X] Run `npm run lint`

> Note: Neither `npm run lint` nor `npm run start` do exist and work unfortunately. The CI is also partially broken in forks due to the signing keys missing. Naturally that **should** be for forks, but makes it harder to actually work on forks. I suggest updating `CONTRIBUTING.md` and this template. Tagging (and changelog) I leave to the maintainers as there is no mention about versions.
